### PR TITLE
Add target supply temperature

### DIFF
--- a/custom_components/vicare/climate.py
+++ b/custom_components/vicare/climate.py
@@ -207,6 +207,11 @@ class ViCareClimate(ClimateEntity):
                     "heating_curve_shift"
                 ] = self._circuit.getHeatingCurveShift()
 
+            with suppress(PyViCareNotSupportedFeatureError):
+                self._attributes[
+                    "target_supply_temperature"
+                ] = self._api.getTargetSupplyTemperature()
+
             self._attributes["vicare_modes"] = self._circuit.getModes()
 
             self._current_action = False


### PR DESCRIPTION
This PR adds `target_supply_temperature` for the current target supply temperature which is calculated and now available via PyViCare