### PR TITLE
Add DHCP discovery config for Viessmann integration

### DIFF
--- a/vicare/manifest.json
+++ b/vicare/manifest.json
@@ -5,5 +5,10 @@
   "codeowners": ["@oischinger"],
   "requirements": ["PyViCare==1.0.0"],
   "iot_class": "cloud_polling",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "dhcp": [
+    {
+      "macaddress": "B87424*"
+    }
+  ]
 }


### PR DESCRIPTION
This PR adds the [DHCP discovery configuration](https://developers.home-assistant.io/docs/creating_integration_manifest/#dhcp) for Viessmann Devices to the manifest. This can be used in combination with PR #43 to jump into the correct config flow for adding new devices.