### PR TITLE
Energy & consumption unit support

### DIFF
--- a/custom_components/vicare/__init__.py
+++ b/custom_components/vicare/__init__.py
@@ -39,6 +39,7 @@ class ViCareRequiredKeysMixin:
     """Mixin for required keys."""
 
     value_getter: Callable[[Device], bool]
+    unit_getter: Callable[[Device], bool | None]
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/vicare/binary_sensor.py
+++ b/custom_components/vicare/binary_sensor.py
@@ -19,7 +19,13 @@ from homeassistant.components.binary_sensor import (
 )
 
 from . import ViCareRequiredKeysMixin
-from .const import DOMAIN, VICARE_API, VICARE_DEVICE_CONFIG, VICARE_NAME
+from .const import (
+    DOMAIN,
+    VICARE_API,
+    VICARE_DEVICE_CONFIG,
+    VICARE_NAME,
+    VICARE_UNIT_TO_DEVICE_CLASS,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,6 +47,7 @@ CIRCUIT_SENSORS: tuple[ViCareBinarySensorEntityDescription, ...] = (
         name="Circulation pump active",
         device_class=DEVICE_CLASS_POWER,
         value_getter=lambda api: api.getCirculationPumpActive(),
+        unit_getter=lambda api: None,
     ),
 )
 
@@ -50,6 +57,7 @@ BURNER_SENSORS: tuple[ViCareBinarySensorEntityDescription, ...] = (
         name="Burner active",
         device_class=DEVICE_CLASS_POWER,
         value_getter=lambda api: api.getActive(),
+        unit_getter=lambda api: None,
     ),
 )
 
@@ -59,6 +67,7 @@ COMPRESSOR_SENSORS: tuple[ViCareBinarySensorEntityDescription, ...] = (
         name="Compressor active",
         device_class=DEVICE_CLASS_POWER,
         value_getter=lambda api: api.getActive(),
+        unit_getter=lambda api: None,
     ),
 )
 
@@ -66,6 +75,13 @@ COMPRESSOR_SENSORS: tuple[ViCareBinarySensorEntityDescription, ...] = (
 def _build_entity(name, vicare_api, device_config, sensor):
     try:
         sensor.value_getter(vicare_api)
+
+        if callable(sensor.unit_getter):
+            with suppress(PyViCareNotSupportedFeatureError):
+                sensor.device_class = VICARE_UNIT_TO_DEVICE_CLASS.get(
+                    sensor.unit_getter(vicare_api)
+                )
+
         _LOGGER.debug("Found entity %s", name)
         return ViCareBinarySensor(
             name,

--- a/custom_components/vicare/binary_sensor.py
+++ b/custom_components/vicare/binary_sensor.py
@@ -25,6 +25,7 @@ from .const import (
     VICARE_DEVICE_CONFIG,
     VICARE_NAME,
     VICARE_UNIT_TO_DEVICE_CLASS,
+    VICARE_UNIT_TO_UNIT_OF_MEASUREMENT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -78,8 +79,10 @@ def _build_entity(name, vicare_api, device_config, sensor):
 
         if callable(sensor.unit_getter):
             with suppress(PyViCareNotSupportedFeatureError):
-                sensor.device_class = VICARE_UNIT_TO_DEVICE_CLASS.get(
-                    sensor.unit_getter(vicare_api)
+                vicare_unit = sensor.unit_getter(vicare_api)
+                sensor.device_class = VICARE_UNIT_TO_DEVICE_CLASS.get(vicare_unit)
+                sensor.native_unit_of_measurement = (
+                    VICARE_UNIT_TO_UNIT_OF_MEASUREMENT.get(vicare_unit)
                 )
 
         _LOGGER.debug("Found entity %s", name)

--- a/custom_components/vicare/const.py
+++ b/custom_components/vicare/const.py
@@ -1,7 +1,12 @@
 """Constants for the ViCare integration."""
 import enum
 
-from homeassistant.const import DEVICE_CLASS_ENERGY, DEVICE_CLASS_GAS
+from homeassistant.const import (
+    DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_GAS,
+    ENERGY_KILO_WATT_HOUR,
+    VOLUME_CUBIC_METERS,
+)
 
 DOMAIN = "vicare"
 
@@ -23,6 +28,11 @@ VICARE_KWH = "kilowattHour"
 VICARE_UNIT_TO_DEVICE_CLASS = {
     VICARE_KWH: DEVICE_CLASS_ENERGY,
     VICARE_CUBIC_METER: DEVICE_CLASS_GAS,
+}
+
+VICARE_UNIT_TO_UNIT_OF_MEASUREMENT = {
+    VICARE_KWH: ENERGY_KILO_WATT_HOUR,
+    VICARE_CUBIC_METER: VOLUME_CUBIC_METERS,
 }
 
 

--- a/custom_components/vicare/const.py
+++ b/custom_components/vicare/const.py
@@ -1,6 +1,8 @@
 """Constants for the ViCare integration."""
 import enum
 
+from homeassistant.const import DEVICE_CLASS_ENERGY, DEVICE_CLASS_GAS
+
 DOMAIN = "vicare"
 
 PLATFORMS = ["climate", "sensor", "binary_sensor", "water_heater"]
@@ -14,6 +16,14 @@ CONF_HEATING_TYPE = "heating_type"
 
 DEFAULT_SCAN_INTERVAL = 60
 DEFAULT_HEATING_TYPE = "auto"
+
+VICARE_CUBIC_METER = "cubicMeter"
+VICARE_KWH = "kilowattHour"
+
+VICARE_UNIT_TO_DEVICE_CLASS = {
+    VICARE_KWH: DEVICE_CLASS_ENERGY,
+    VICARE_CUBIC_METER: DEVICE_CLASS_GAS,
+}
 
 
 class HeatingType(enum.Enum):

--- a/custom_components/vicare/manifest.json
+++ b/custom_components/vicare/manifest.json
@@ -3,7 +3,7 @@
   "name": "Viessmann ViCare",
   "documentation": "https://www.home-assistant.io/integrations/vicare",
   "codeowners": ["@oischinger"],
-  "requirements": ["PyViCare==2.10.0"],
+  "requirements": ["PyViCare==2.13.0"],
   "iot_class": "cloud_polling",
   "config_flow": true,
   "version": "2.0.0",

--- a/custom_components/vicare/sensor.py
+++ b/custom_components/vicare/sensor.py
@@ -37,6 +37,7 @@ from .const import (
     VICARE_DEVICE_CONFIG,
     VICARE_NAME,
     VICARE_UNIT_TO_DEVICE_CLASS,
+    VICARE_UNIT_TO_UNIT_OF_MEASUREMENT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -326,8 +327,10 @@ def _build_entity(name, vicare_api, device_config, sensor):
 
         if callable(sensor.unit_getter):
             with suppress(PyViCareNotSupportedFeatureError):
-                sensor.device_class = VICARE_UNIT_TO_DEVICE_CLASS.get(
-                    sensor.unit_getter(vicare_api)
+                vicare_unit = sensor.unit_getter(vicare_api)
+                sensor.device_class = VICARE_UNIT_TO_DEVICE_CLASS.get(vicare_unit)
+                sensor.native_unit_of_measurement = (
+                    VICARE_UNIT_TO_UNIT_OF_MEASUREMENT.get(vicare_unit)
                 )
         _LOGGER.debug("Found entity %s", name)
         return ViCareSensor(

--- a/custom_components/vicare/sensor.py
+++ b/custom_components/vicare/sensor.py
@@ -328,10 +328,11 @@ def _build_entity(name, vicare_api, device_config, sensor):
         if callable(sensor.unit_getter):
             with suppress(PyViCareNotSupportedFeatureError):
                 vicare_unit = sensor.unit_getter(vicare_api)
-                sensor.device_class = VICARE_UNIT_TO_DEVICE_CLASS.get(vicare_unit)
-                sensor.native_unit_of_measurement = (
-                    VICARE_UNIT_TO_UNIT_OF_MEASUREMENT.get(vicare_unit)
-                )
+                if vicare_unit is not None:
+                    sensor.device_class = VICARE_UNIT_TO_DEVICE_CLASS.get(vicare_unit)
+                    sensor.native_unit_of_measurement = (
+                        VICARE_UNIT_TO_UNIT_OF_MEASUREMENT.get(vicare_unit)
+                    )
         _LOGGER.debug("Found entity %s", name)
         return ViCareSensor(
             name,


### PR DESCRIPTION
This change supports the Home Assistant Energy Dasboard and respects the newly
added units provided by ViCare for the consumption data

![image](https://user-images.githubusercontent.com/7779765/137197525-db0e12df-aa9f-41ce-9cfc-e05c819caee7.png)
