### PR TITLE
fix warning for macaddress access

### DIFF
--- a/custom_components/vicare/config_flow.py
+++ b/custom_components/vicare/config_flow.py
@@ -75,7 +75,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_dhcp(self, discovery_info):
         """Invoke when a Viessmann MAC address is discovered on the network."""
-        formatted_mac = format_mac(discovery_info[MAC_ADDRESS])
+        formatted_mac = format_mac(discovery_info.macaddress)
         _LOGGER.info("Found device with mac %s", formatted_mac)
 
         await self.async_set_unique_id(formatted_mac)


### PR DESCRIPTION
Fixes the following warning:


> Detected integration that accessed discovery_info['macaddress'] instead of discovery_info.macaddress; this will fail in version 2022.6. Please report issue to the custom component author for vicare using this method at custom_components/vicare/config_flow.py, line 78: formatted_mac = format_mac(discovery_info[MAC_ADDRESS])
