### PR TITLE
Fix precision of target & current temperature

### DIFF
--- a/custom_components/vicare/climate.py
+++ b/custom_components/vicare/climate.py
@@ -23,7 +23,12 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, TEMP_CELSIUS
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    PRECISION_TENTHS,
+    PRECISION_WHOLE,
+    TEMP_CELSIUS,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
@@ -306,6 +311,11 @@ class ViCareClimate(ClimateEntity):
     @property
     def precision(self):
         """Return the precision of the system."""
+        return PRECISION_TENTHS
+
+    @property
+    def target_temperature_step(self) -> float:
+        """Set target temperature step to wholes."""
         return PRECISION_WHOLE
 
     def set_temperature(self, **kwargs):

--- a/custom_components/vicare/water_heater.py
+++ b/custom_components/vicare/water_heater.py
@@ -14,7 +14,12 @@ from homeassistant.components.water_heater import (
     WaterHeaterEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, TEMP_CELSIUS
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    PRECISION_TENTHS,
+    PRECISION_WHOLE,
+    TEMP_CELSIUS,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -191,9 +196,14 @@ class ViCareWater(WaterHeaterEntity):
         return VICARE_TEMP_WATER_MAX
 
     @property
+    def target_temperature_step(self) -> float:
+        """Set target temperature step to wholes."""
+        return PRECISION_WHOLE
+
+    @property
     def precision(self):
         """Return the precision of the system."""
-        return PRECISION_WHOLE
+        return PRECISION_TENTHS
 
     @property
     def current_operation(self):


### PR DESCRIPTION
Vicare initially had "whole" precision set. I was mislead that this is the
precision to be used for the target temperature.
Instead it is actually the precision of the current temperature.
PyViCare actually delivers a precision of tenths of degrees for current
temperature.

This change:
Changes current temperature precision to TENTHS
Adds target_temperature_step to actually make WHOLE precision effective for
setting temperature.