### PR TITLE
Patch Logger to reduce repeated messages frequency

### DIFF
--- a/custom_components/vicare/__init__.py
+++ b/custom_components/vicare/__init__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-import logging
 
 from PyViCare.PyViCare import PyViCare
 from PyViCare.PyViCareDevice import Device
@@ -23,8 +22,9 @@ from .const import (
     VICARE_DEVICE_CONFIG,
     HeatingType,
 )
+from . import helpers
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = helpers.getLogger(__name__)
 
 
 @dataclass()

--- a/custom_components/vicare/binary_sensor.py
+++ b/custom_components/vicare/binary_sensor.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from contextlib import suppress
 from dataclasses import dataclass
-import logging
 
 from PyViCare.PyViCareUtils import (
     PyViCareInvalidDataError,
@@ -24,8 +23,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ViCareRequiredKeysMixin
 from .const import DOMAIN, VICARE_API, VICARE_DEVICE_CONFIG, VICARE_NAME
+from . import helpers
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = helpers.getLogger(__name__)
 
 
 @dataclass

--- a/custom_components/vicare/button.py
+++ b/custom_components/vicare/button.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from contextlib import suppress
 from dataclasses import dataclass
-import logging
 
 from PyViCare.PyViCareUtils import (
     PyViCareInvalidDataError,
@@ -20,8 +19,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ViCareRequiredKeysMixinWithSet
 from .const import DOMAIN, VICARE_API, VICARE_DEVICE_CONFIG, VICARE_NAME
+from . import helpers
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = helpers.getLogger(__name__)
 
 BUTTON_DHW_ACTIVATE_ONETIME_CHARGE = "activate_onetimecharge"
 

--- a/custom_components/vicare/climate.py
+++ b/custom_components/vicare/climate.py
@@ -2,8 +2,7 @@
 from __future__ import annotations
 
 from contextlib import suppress
-import logging
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from PyViCare.PyViCareUtils import (
     PyViCareCommandError,
@@ -43,8 +42,9 @@ from .const import (
     VICARE_DEVICE_CONFIG,
     VICARE_NAME,
 )
+from . import helpers
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = helpers.getLogger(__name__)
 
 SERVICE_SET_VICARE_MODE = "set_vicare_mode"
 SERVICE_SET_VICARE_MODE_ATTR_MODE = "vicare_mode"
@@ -99,8 +99,11 @@ HA_TO_VICARE_PRESET_HEATING = {
     PRESET_NONE: VICARE_PROGRAM_NORMAL,
 }
 
+if TYPE_CHECKING:
+    from PyViCare import PyViCareDevice, PyViCareDeviceConfig
 
-def _get_circuits(vicare_api):
+
+def _get_circuits(vicare_api: 'PyViCareDevice.Device'):
     """Return the list of circuits."""
     try:
         return vicare_api.circuits
@@ -117,7 +120,7 @@ async def async_setup_entry(
     """Set up the ViCare climate platform."""
     name = VICARE_NAME
     entities = []
-    api = hass.data[DOMAIN][config_entry.entry_id][VICARE_API]
+    api: 'PyViCareDevice.Device' = hass.data[DOMAIN][config_entry.entry_id][VICARE_API]
     circuits = await hass.async_add_executor_job(_get_circuits, api)
 
     for circuit in circuits:
@@ -163,7 +166,14 @@ class ViCareClimate(ClimateEntity):
     )
     _attr_temperature_unit = TEMP_CELSIUS
 
-    def __init__(self, name, api, circuit, device_config, heating_type):
+    def __init__(
+        self,
+        name,
+        api: 'PyViCareDevice.Device',
+        circuit: 'PyViCareDevice.HeatingCircuit',
+        device_config: 'PyViCareDeviceConfig.PyViCareDeviceConfig',
+        heating_type
+    ):
         """Initialize the climate device."""
         self._name = name
         self._state = None

--- a/custom_components/vicare/helpers.py
+++ b/custom_components/vicare/helpers.py
@@ -1,0 +1,44 @@
+""" Helper utilities"""
+import logging
+from time import time
+
+
+def getLogger(name):
+    """
+    Replaces the default Logger with our wrapped implementation:
+    replace your logging.getLogger with helpers.getLogger et voilà
+    """
+    logger = logging.getLogger(name)
+    logger.__class__ = type('Logger', (_Logger, logger.__class__, ), {})
+    return logger
+
+
+class _Logger(logging.Logger):
+    """
+    This wrapper will 'filter' log messages and avoid
+    verbose over-logging for the same message by using a timeout
+    to prevent repeating the very same log before the timeout expires.
+    The implementation 'hacks' a standard Logger instance by mixin-ing
+    """
+
+    # default timeout: these can be overriden at the log call level
+    # by passing in the 'timeout=' param
+    # for example: LOGGER.error("This error will %s be logged again", "soon", timeout=5)
+    # it can also be overriden at the 'Logger' instance level
+    default_timeout = 60 * 60 * 8
+    # cache of logged messages with relative last-thrown-epoch
+    _LOGGER_TIMEOUTS = {}
+
+    def _log(self, level, msg, args, **kwargs): # pylint: disable=arguments-differ
+
+        timeout = kwargs.pop('timeout', self.default_timeout)
+        epoch = time()
+        trap_key = (hash(msg), args)
+        if trap_key in _Logger._LOGGER_TIMEOUTS:
+            if ((epoch - _Logger._LOGGER_TIMEOUTS[trap_key]) < timeout):
+                if self.isEnabledFor(logging.DEBUG):
+                    super()._log(logging.DEBUG, f"dropped log message for {msg}", args)
+                return
+
+        super()._log(level, msg, args, **kwargs)
+        _Logger._LOGGER_TIMEOUTS[trap_key] = epoch

--- a/custom_components/vicare/sensor.py
+++ b/custom_components/vicare/sensor.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
-import logging
 
 from PyViCare.PyViCareDevice import Device
 from PyViCare.PyViCareUtils import (
@@ -42,8 +41,9 @@ from .const import (
     VICARE_UNIT_TO_DEVICE_CLASS,
     VICARE_UNIT_TO_UNIT_OF_MEASUREMENT,
 )
+from . import helpers
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = helpers.getLogger(__name__)
 
 
 @dataclass

--- a/custom_components/vicare/water_heater.py
+++ b/custom_components/vicare/water_heater.py
@@ -1,6 +1,5 @@
 """Viessmann ViCare water_heater device."""
 from contextlib import suppress
-import logging
 from typing import Any
 
 from PyViCare.PyViCareUtils import (
@@ -32,8 +31,9 @@ from .const import (
     VICARE_DEVICE_CONFIG,
     VICARE_NAME,
 )
+from . import helpers
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = helpers.getLogger(__name__)
 
 VICARE_MODE_DHW = "dhw"
 VICARE_MODE_HEATING = "heating"


### PR DESCRIPTION
Hello Hans,
Sorry for this 'unsolicited' PR but I wanted to submit you a proposal for reducing the frequency of the integration logs which lead my working HA to some stressful situations (I have logging in ramdisk on my pi - so blame on me for that :)
This happened sometimes when the Viessmann api was unavailable for many hours and my HA log got overwhelmed. I saw other complaints about this on HA forums too and I've decided to share with you my idea about the matter without opening an issue but directly here:

This patch basically sets a timeout (fixed in code but customizable 'per call') where a logged message doesnt get repeated until the timeout elapses. The idea is that once you know something wrong is happening there's no need to repeat this on every entity update cycle or so since the situation is likely stalling somewehere else and there's no actual solution (As stated before this happened a couple of time when the Viessmann api went offline for a long time)

The logic for 'gating' each message is handled in the patched `Logger` class (hidden behind `_Logger` in the added module `helpers.py`)

There's another issue in my opinion in the fact the entity `update` code is not totally tryed/catched so it happens sometimes some exceptions pop up in the runner and this starts an annoying stack dump also impairing the HA log readability. I'm thinking about a general catcher which just logs the error message in normal circumstances and eventually sets the stack trace only when logging is configured for DEBUG
I'm working on a separate PR for this which I should be able to deliver in 1 or 2 days so to share the ideas
