### PR TITLE
avoid exceptions raising up to HA core

### DIFF
--- a/custom_components/vicare/__init__.py
+++ b/custom_components/vicare/__init__.py
@@ -2,16 +2,25 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from contextlib import contextmanager
 from dataclasses import dataclass
 import logging
+import typing
 
 from PyViCare.PyViCare import PyViCare
 from PyViCare.PyViCareDevice import Device
-
+from PyViCare.PyViCareUtils import (
+    PyViCareInvalidDataError,
+    PyViCareRateLimitError,
+    PyViCareInvalidCredentialsError,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.storage import STORAGE_DIR
+import requests
 
 from .const import (
     CONF_HEATING_TYPE,
@@ -24,7 +33,42 @@ from .const import (
     HeatingType,
 )
 
+if typing.TYPE_CHECKING:
+    from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
+
+
 _LOGGER = logging.getLogger(__name__)
+
+
+class ViCareError(Exception):
+    """A typed exception to identify errors raised from ViCare code"""
+
+
+class ViCareEntity:
+    """Abstract base entity class for ViCare entities"""
+
+    _logger: 'logging.Logger' # using the logger from the inheriting class
+    _device_config: 'PyViCareDeviceConfig'
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info for this device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device_config.getConfig().serial)},
+            name=self._device_config.getModel(),
+            manufacturer="Viessmann",
+            model=self._device_config.getModel(),
+            configuration_url="https://developer.viessmann.com/",
+        )
+
+    def _internal_update(self):
+        """virtual abstract: override to actually do the update"""
+        raise NotImplementedError()
+
+    def update(self):
+        """Let HA know there has been an update from the ViCare API."""
+        with managed_exceptions(self._logger):
+            self._internal_update()
 
 
 @dataclass()
@@ -42,6 +86,27 @@ class ViCareRequiredKeysMixinWithSet:
     value_setter: Callable[[Device], bool]
 
 
+@contextmanager
+def managed_exceptions(logger: 'logging.Logger'):
+    try:
+        yield
+    except requests.exceptions.ConnectionError:
+        logger.error("Unable to retrieve data from ViCare server")
+    except PyViCareRateLimitError as limit_exception:
+        logger.error("Vicare API rate limit exceeded: %s", limit_exception)
+    except PyViCareInvalidDataError as invalid_data_exception:
+        logger.error("Invalid data from Vicare server: %s", invalid_data_exception)
+    except ValueError:
+        logger.error("Unable to decode data from ViCare server")
+    except ViCareError as error:
+        logger.error("ViCare error: %s", str(error))
+    except Exception as error:
+        if logger.isEnabledFor(logging.DEBUG):
+            raise error
+        else:
+            logger.error("Unexpected %s: %s", type(error).__name__, str(error))
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up from config entry."""
     _LOGGER.debug("Setting up ViCare component")
@@ -49,11 +114,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN] = {}
     hass.data[DOMAIN][entry.entry_id] = {}
 
-    await hass.async_add_executor_job(setup_vicare_api, hass, entry)
+    try:
+        await hass.async_add_executor_job(setup_vicare_api, hass, entry)
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+        return True
+    except PyViCareInvalidCredentialsError as auth_error:
+        raise ConfigEntryAuthFailed from auth_error
+    except Exception as error:
+        raise ConfigEntryNotReady from error
 
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    return True
 
 
 def vicare_login(hass, entry_data):


### PR DESCRIPTION
Hello, 
This is the second part of my proposal to reduce HA log cluttering.

This PR is rather 'intensive' on the code and I'll try to explain the rationale and the coding choices:

- When an exception is not handled in the integration code and 'pops' up to HA core, the logging is very verbose comprising the full call stack. Of course, an unhandled exception is likely telling something important and we can't simply silence it but still, the verbosity might scare the 'production user' and might be totally useless. The idea for this PR is to simply catch everything and just log it preventing the stack dump to pollute the HA log for the standard production scenario. Instead, when DEBUG logging is enabled, the behavior is as before: let the exception float up to HA core so to dump the full stack log and help debugging so far.
- Implementation. I've defined a simple and general context manager readily available wherever we want to trap and 'smartly' log code exceptions. I've already applied this 'exception trapper' wherever the calling code is the HA core so to filter out exceptions.
- Preservation of code logic. Whenever applying the context I've tried to respect the existent code logic just wrapping the code in the context manager so to expect the less 'disruption' to existing logic. Having not partecipated in design and development of this code I'm aware I'm really ignorant about all the underlying choices and I don't want to disrupt any apparent or non-apparent logic behind it.
-  The integration setup call (`async_setup_entry`) has received a different approach (the logic was a bit remanaged) so to return more specific exceptions to HA core in order to let it manage the problem (by either signaling an auth error or in general telling the core to try reload the configuration entry at a later stage)
- Testing. Beside running the pytests, I've succesfully tested the integration behavior with debug logging enabled and disabled and it looks like correctly following the design
- Rafactoring. An initial approach was based off generating a superclass for the ViCare entities (`'ViCareEntity'`) in order to use a single point of entry for the `entity->update()` call and put the exception logic there. It was straightful enough since the exceptions blocks in all the implementations were the same. Then, the need to trap exceptions in other parts of the code suggested me a different approach based off context managers and that became the solution but the common super class was a nice idea (in my opinion - very personal declination). Now it still implements the single point of entry for the update() call in every entity even if rather simple but can provide other common behaviors (just the `entity->device_info()` right now)